### PR TITLE
Make header links go to /

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,9 +19,9 @@
     <header class="page-header" role="banner">
       <h1 class="project-name">UP.rising</h1>
       <h2 class="project-tagline">Es soll als Phönix aus der Asche steigen: Wir wollen das StuPa retten</h2>
-      <a href="#status-quo-asche" class="btn">Wieso?</a>
-      <a href="#unser-plan-gemeinsames-brüten" class="btn">Wie soll das gehen?</a>
-      <a href="#unsere-prinzipien" class="btn">Wer wir sind</a>
+      <a href="/#status-quo-asche" class="btn">Wieso?</a>
+      <a href="/#unser-plan-gemeinsames-brüten" class="btn">Wie soll das gehen?</a>
+      <a href="/#unsere-prinzipien" class="btn">Wer wir sind</a>
     </header>
 
     <main id="content" class="main-content" role="main">


### PR DESCRIPTION
The header links currently go to the anchor on the current page, which would not work for page.html. This PR adds a `/` before the anchor links to always force navigation to the `index.html`